### PR TITLE
speed up zip file generation

### DIFF
--- a/pages/api/zip/index.js
+++ b/pages/api/zip/index.js
@@ -1,34 +1,47 @@
-import JSZip from 'jszip';
-var request = require('request').defaults({ encoding: null });
+import JSZip from "jszip";
+var request = require("request").defaults({ encoding: null });
+
+async function downloadImage(url) {
+  return new Promise((resolve, reject) => {
+    request.get(url, (error, response, body) => {
+      if (!error && response.statusCode == 200) {
+        const dataUri =
+          "data:" +
+          response.headers["content-type"] +
+          ";base64," +
+          Buffer.from(body).toString("base64");
+        resolve(dataUri);
+      } else {
+        reject(
+          error || new Error(`Response status code: ${response.statusCode}`)
+        );
+      }
+    });
+  });
+}
 
 async function convertB64ToZip(array_of_b64_images) {
-    return new Promise(async resolve1 => {
-        const zip = new JSZip();
-        // Draw each JPEG frame on the canvas and add it to the animated GIF
-        for (let [i, data_uri] of array_of_b64_images.entries()) {
-            console.log(data_uri);
-            if (data_uri.indexOf('data:') !== 0) {
-                data_uri = await new Promise(async resolve2 => {
-                    request.get(data_uri, (error, response, body) => {
-                        if (!error && response.statusCode == 200) {
-                            data_uri = "data:" + response.headers["content-type"] + ";base64," + Buffer.from(body).toString('base64');
-                            resolve2(data_uri);
-                        }
-                    })
-                });
-            }
-            await new Promise(resolve3 => {
-                resolve3(zip.file(`image_${i}.jpeg`, data_uri.split(',')[1], { base64: true }));
-            });
+  const zip = new JSZip();
+  const downloadPromises = array_of_b64_images.map(async (dataUri, i) => {
+    if (dataUri.indexOf("data:") !== 0) {
+      dataUri = await downloadImage(dataUri);
+    }
+    zip.file(`image_${i}.jpeg`, dataUri.split(",")[1], { base64: true });
+  });
 
-        }
-        await zip.generateAsync({ type: 'base64' }).then((data) => { resolve1(JSON.stringify("data:application/zip;base64," + data)) })
-    })
+  await Promise.all(downloadPromises);
+
+  const zipData = await zip.generateAsync({ type: "base64" });
+  return JSON.stringify("data:application/zip;base64," + zipData);
 }
 
 export default async function handler(req, res) {
+  try {
     let gif = await convertB64ToZip(req.body.images);
-
     res.statusCode = 201;
     res.end(gif);
+  } catch (error) {
+    res.statusCode = 500;
+    res.end(`Error: ${error.message}`);
+  }
 }


### PR DESCRIPTION
This PR refactors the zip-generating API endpoint to download all the images in parallel, instead of serially. This should make this endpoint way faster.

cc @chigozienri 